### PR TITLE
fix: corregir namespaces en templates de test

### DIFF
--- a/.plans/templates/styles/aggregate/style-test-aggregate.md
+++ b/.plans/templates/styles/aggregate/style-test-aggregate.md
@@ -3,7 +3,7 @@
 ## Estructura
 
 ```csharp
-namespace {Project}.UnitTests.Features.{Feature}.Domain.{Aggregate}Aggregate;
+namespace {Project}.UnitTests.{Feature}.Domain.{Aggregate}AggregateTests;
 
 public class {Aggregate}Tests
 {
@@ -122,7 +122,7 @@ public class {Aggregate}Tests
 
 ## Reglas
 
-- Namespace: `{Project}.UnitTests.Features.{Feature}.Domain.{Aggregate}Aggregate`
+- Namespace: `{Project}.UnitTests.{Feature}.Domain.{Aggregate}AggregateTests`
 - **No `using`** → Van en `GlobalUsings.cs`
 - **No XML docs**
 - Clase: `{Aggregate}Tests`

--- a/.plans/templates/styles/aggregate/style-test-command.md
+++ b/.plans/templates/styles/aggregate/style-test-command.md
@@ -12,7 +12,7 @@
 ## Estructura
 
 ```csharp
-namespace {Project}.UnitTests.Features.{Feature}.Domain.{Aggregate}Aggregate.Commands.{Aggregate};
+namespace {Project}.UnitTests.{Feature}.Domain.{Aggregate}AggregateTests.Commands.{Aggregate}Tests;
 
 public class {Aggregate}{Command}Tests
 {

--- a/.plans/templates/styles/enum/style-test-enum.md
+++ b/.plans/templates/styles/enum/style-test-enum.md
@@ -3,7 +3,7 @@
 ## Estructura
 
 ```csharp
-namespace {Project}.UnitTests.Features.{Feature}.Domain.{Aggregate}Aggregate.Enums;
+namespace {Project}.UnitTests.{Feature}.Domain.{Aggregate}AggregateTests.EnumsTests;
 
 public class {EnumName}Tests
 {
@@ -33,7 +33,7 @@ public class {EnumName}Tests
 
 ## Reglas
 
-- Namespace: `{Project}.UnitTests.Features.{Feature}.Domain.{Aggregate}Aggregate.Enums`
+- Namespace: `{Project}.UnitTests.{Feature}.Domain.{Aggregate}AggregateTests.EnumsTests`
 - **No `using`** → Van en `GlobalUsings.cs`
 - **No XML docs**
 - Clase: `{EnumName}Tests`

--- a/.plans/templates/styles/slice/style-slice-test-integration.md
+++ b/.plans/templates/styles/slice/style-slice-test-integration.md
@@ -63,7 +63,7 @@ public class {Project}WebApplicationFixture : IClassFixture<WebApplicationFactor
 
 ## Estructura de Tests
 ```csharp
-namespace {Project}.IntegrationTests.Features.{Feature}.Api.{Commands|Queries}.{Aggregates};
+namespace {Project}.IntegrationTests.{Feature}.Api.{Aggregate}AggregateTests.{Commands|Queries};
 
 public class {Action}{Aggregate}Tests : {Project}WebApplicationFixture
 {

--- a/.plans/templates/styles/slice/style-slice-test-unit.md
+++ b/.plans/templates/styles/slice/style-slice-test-unit.md
@@ -13,7 +13,7 @@ Testea desde el Handler hasta el Repository (mock).
 ## Estructura
 
 ```csharp
-namespace {Project}.UnitTests.Features.{Feature}.Api.{Commands|Queries}.{Aggregates};
+namespace {Project}.UnitTests.{Feature}.Api.{Aggregate}AggregateTests.{Commands|Queries};
 
 public class {Action}{Aggregate}Tests
 {

--- a/.plans/templates/styles/valueobject/style-test-validator.md
+++ b/.plans/templates/styles/valueobject/style-test-validator.md
@@ -3,7 +3,7 @@
 ## Estructura
 
 ```csharp
-namespace {Project}.UnitTests.Features.{Feature}.Domain.{Aggregate}Aggregate.ValueObjects;
+namespace {Project}.UnitTests.{Feature}.Domain.{Aggregate}AggregateTests.ValueObjectsTests;
 
 public class {ValueObject}ValidatorTests
 {

--- a/.plans/templates/styles/valueobject/style-test-valueobject.md
+++ b/.plans/templates/styles/valueobject/style-test-valueobject.md
@@ -3,7 +3,7 @@
 ## Estructura
 
 ```csharp
-namespace {Project}.UnitTests.Features.{Feature}.Domain.{Aggregate}Aggregate.ValueObjects;
+namespace {Project}.UnitTests.{Feature}.Domain.{Aggregate}AggregateTests.ValueObjectsTests;
 
 public class {ValueObject}Tests
 {
@@ -57,7 +57,7 @@ public class {ValueObject}Tests
 
 ## Reglas
 
-- Namespace: `{Project}.UnitTests.Features.{Feature}.Domain.{Aggregate}Aggregate.ValueObjects`
+- Namespace: `{Project}.UnitTests.{Feature}.Domain.{Aggregate}AggregateTests.ValueObjectsTests`
 - **No `using`** → Van en `GlobalUsings.cs`
 - **No XML docs**
 - Clase: `{ValueObject}Tests`


### PR DESCRIPTION
- Eliminar 'Features.' del path de namespaces
- Añadir sufijo 'Tests' a AggregateTests, EnumsTests, ValueObjectsTests
- Alinear namespaces con estructura de carpetas en tests/